### PR TITLE
feat(build): publishing cron

### DIFF
--- a/.github/workflows/.gh-pages.yml
+++ b/.github/workflows/.gh-pages.yml
@@ -10,8 +10,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-#  schedule:
-#    - cron: "0 9 * * 1-5"
+  schedule:
+    - cron: "0 9 * * 1-5"
 
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Since posts can be scheduled in time, a cron job is activated to run build daily. This way any posts that are not in draft, but scheduled in the future, would end up in the website.

Closes #10 